### PR TITLE
fix(pdf): Use direct font URLs for PDF generation

### DIFF
--- a/src/components/RegistrationPDF.tsx
+++ b/src/components/RegistrationPDF.tsx
@@ -3,7 +3,10 @@ import { Document, Page, Text, View, StyleSheet, Image, pdf, Font } from '@react
 
 Font.register({
   family: 'Cairo',
-  src: 'https://fonts.googleapis.com/css2?family=Cairo:wght@400;700&display=swap',
+  fonts: [
+    { src: 'https://fonts.gstatic.com/s/cairo/v30/SLXgc1nY6HkvangtZmpQdkhzfH5lkSs2SgRjCAGMQ1z0hOA-W1Q.ttf' },
+    { src: 'https://fonts.gstatic.com/s/cairo/v30/SLXgc1nY6HkvangtZmpQdkhzfH5lkSs2SgRjCAGMQ1z0hAc5W1Q.ttf', fontWeight: 700 },
+  ]
 });
 
 


### PR DESCRIPTION
The PDF generation was failing because `@react-pdf/renderer` was being initialized with a Google Fonts CSS URL instead of a direct URL to a font file. This caused an "Unknown font format" error.

This commit fixes the issue by updating the `Font.register` call in `RegistrationPDF.tsx` to use the direct URLs to the `.ttf` files for the 'Cairo' font, for both regular and bold weights.