### PR TITLE
This commit fixes two issues related to the login flow:

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -132,7 +132,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
           const fetchWithTimeout = Promise.race([
             fetchProfile(session.user.id),
             new Promise((_, reject) => 
-              setTimeout(() => reject(new Error('Profile fetch timeout')), 5000)
+              setTimeout(() => reject(new Error('Profile fetch timeout')), 10000) // Increased to 10s
             )
           ]);
           


### PR DESCRIPTION
1.  **Profile Fetch Timeout:** The application was frequently timing out when fetching your profile, especially on slower connections. This was because the timeout was set to a tight 5 seconds, which was not always enough for the two sequential database calls in the `fetchProfile` function. The timeout has been increased to 10 seconds to make the application more resilient.

2.  **Admin Login Redirect:** The failure to redirect the super admin to the creation page after login was a side effect of the profile fetch timing out. By fixing the timeout, the redirect now proceeds as expected.