### PR TITLE
This commit fixes a JavaScript crash on the generic Login page.

### DIFF
--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -11,7 +11,7 @@ import { z } from 'zod';
 import { useToast } from '@/hooks/use-toast';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
-import { LogIn, Eye, EyeOff } from 'lucide-react';
+import { LogIn, Eye, EyeOff, GraduationCap } from 'lucide-react';
 
 const loginSchema = z.object({
   email: z.string().email('Invalid email address'),


### PR DESCRIPTION
The page was using the `GraduationCap` icon from `lucide-react` in its JSX, but the component was not being imported. This resulted in a `ReferenceError: GraduationCap is not defined` in the browser, preventing the page from rendering.

The fix adds `GraduationCap` to the import statement in `src/pages/Login.tsx`.