### PR TITLE
Fix: Update placeholder email for platform admin login

### DIFF
--- a/src/pages/PlatformAdmin/Login.tsx
+++ b/src/pages/PlatformAdmin/Login.tsx
@@ -110,7 +110,7 @@ const PlatformAdminLogin = () => {
                       <FormControl>
                         <Input
                           type="email"
-                          placeholder="superadmin@example.com"
+                          placeholder="superadmin@creator.com"
                           {...field}
                           className="bg-gray-700 border-gray-600 text-white"
                         />


### PR DESCRIPTION
The placeholder for the email field on the platform admin login page showed "superadmin@example.com", which was incorrect.

The correct email, as defined in the database migration script for the super admin user, is "superadmin@creator.com".

I have updated the placeholder to the correct email address to avoid confusion and guide you to enter the correct credentials.