### PR TITLE
Fix: Correct platform admin routing to prevent infinite loading

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -91,9 +91,10 @@ const App = () => {
             <Route path="/site/:subdomain/gallery" element={<AcademyWebsite section="gallery" />} />
 
             {/* Platform Admin Routes */}
+            <Route path="/platform-admin/login" element={<PlatformAdminLogin />} />
             <Route path="/platform-admin" element={<PlatformAdminRoute />}>
-              <Route index element={<PlatformAdminDashboard />} />
-              <Route path="login" element={<PlatformAdminLogin />} />
+              <Route index element={<Navigate to="/platform-admin/dashboard" replace />} />
+              <Route path="dashboard" element={<PlatformAdminDashboard />} />
               <Route path="academies" element={<AcademyManagement />} />
               <Route path="academies/create" element={<CreateAcademyForm />} />
               <Route path="academies/:id/edit" element={<EditAcademyForm />} />


### PR DESCRIPTION
The application was getting stuck in an infinite loading state because the `/platform-admin/login` route was incorrectly placed within the `PlatformAdminRoute` guard. This created a circular dependency where the login page could never be rendered.

This change moves the `/platform-admin/login` route outside of the protected route wrapper, making it a public route. The `PlatformAdminRoute` now correctly guards the authenticated platform admin pages and redirects unauthenticated users to the login page.