### PR TITLE
Feat: Add Suspense boundary for lazy-loaded routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,9 +73,10 @@ const App = () => {
     <QueryClientProvider client={queryClient}>
       <TooltipProvider>
         <BrowserRouter>
-          <Routes>
-            {/* Public Routes */}
-            <Route path="/" element={<Index />} />
+          <React.Suspense fallback={<div className="flex items-center justify-center min-h-screen">Loading...</div>}>
+            <Routes>
+              {/* Public Routes */}
+              <Route path="/" element={<Index />} />
             <Route path="/login" element={<Login />} />
             <Route path="/forgot-password" element={<ForgotPassword />} />
             <Route path="/reset-password/:token" element={<ResetPassword />} />
@@ -165,7 +166,8 @@ const App = () => {
             
             {/* Catch all - redirect to home */}
             <Route path="*" element={<Navigate to="/" />} />
-          </Routes>
+            </Routes>
+          </React.Suspense>
           <Toaster />
           <Sonner />
         </BrowserRouter>


### PR DESCRIPTION
The application was not providing a fallback UI while lazy-loaded components were being fetched, which could give the appearance of a frozen or slow-loading application.

This change wraps the main `<Routes>` component in a `<React.Suspense>` boundary. This ensures that a loading indicator is shown to you while you are waiting for the requested route's component to be downloaded and rendered.