### PR TITLE
Fix: Correct login form loading state

### DIFF
--- a/src/pages/PlatformAdmin/Login.tsx
+++ b/src/pages/PlatformAdmin/Login.tsx
@@ -46,7 +46,6 @@ const PlatformAdminLogin = () => {
           variant: 'destructive',
         });
         setIsLoading(false);
-        return;
       }
 
       // After successful sign-in, get the user to check their role from the session


### PR DESCRIPTION
The login form was getting stuck in the "Signing In..." state because a `return` statement was preventing the `finally` block from being executed in the case of a login error.

This change removes the `return` statement from the `if (signInError)` block in the `onSubmit` function. This ensures that the `finally` block is always executed, which in turn sets the loading state to `false` and allows you to attempt to log in again.