### PR TITLE
fix(auth): Grant platform admins access via RLS policies

### DIFF
--- a/supabase/migrations/20250805203117_fix_platform_admin_rls_policies.sql
+++ b/supabase/migrations/20250805203117_fix_platform_admin_rls_policies.sql
@@ -1,0 +1,42 @@
+-- Migration to fix RLS policies for platform admins
+
+-- The existing RLS policies are too restrictive and do not account for the platform_admin role.
+-- This migration updates the key policies to grant platform admins the necessary access.
+
+-- 1. Update RLS policy on public.academies
+-- The existing policy from a previous migration only covers SELECT. We need full access.
+DROP POLICY IF EXISTS "Platform admins can manage academies" ON public.academies;
+CREATE POLICY "Platform admins can manage academies"
+ON public.academies
+FOR ALL
+USING (public.is_platform_admin())
+WITH CHECK (public.is_platform_admin());
+
+-- 2. Update RLS policy on public.profiles
+-- This allows platform admins to see all user profiles, which is necessary for user management.
+DROP POLICY IF EXISTS "Admins can view profiles in their academy" ON public.profiles;
+CREATE POLICY "Admins can view profiles in their academy" ON public.profiles
+  FOR SELECT USING (
+    (get_current_user_role() IN ('director', 'comptabilite_chief') AND academy_id = get_academy_id_from_user(auth.uid()))
+    OR public.is_platform_admin()
+  );
+
+DROP POLICY IF EXISTS "Admins can update profiles in their academy" ON public.profiles;
+CREATE POLICY "Admins can update profiles in their academy" ON public.profiles
+  FOR UPDATE USING (
+    (get_current_user_role() IN ('director', 'comptabilite_chief') AND academy_id = get_academy_id_from_user(auth.uid()))
+    OR public.is_platform_admin()
+  ) WITH CHECK (
+    (get_current_user_role() IN ('director', 'comptabilite_chief') AND academy_id = get_academy_id_from_user(auth.uid()))
+    OR public.is_platform_admin()
+  );
+
+-- Allow platform admins to insert new profiles (e.g., for other admins)
+DROP POLICY IF EXISTS "Admins can insert profiles for their academy" ON public.profiles;
+CREATE POLICY "Admins can insert profiles for their academy" ON public.profiles
+  FOR INSERT WITH CHECK (
+    (get_current_user_role() IN ('director', 'comptabilite_chief') AND profiles.academy_id = get_academy_id_from_user(auth.uid()))
+    OR public.is_platform_admin()
+  );
+
+RAISE NOTICE 'RLS policies for platform admins have been updated.';


### PR DESCRIPTION
The superadmin login was failing because the database's Row Level Security (RLS) policies did not account for the 'platform_admin' role. All data access was scoped to an academy, but the platform admin has no academy, effectively locking them out from viewing any data after login.

This commit introduces a new database migration that updates the RLS policies for critical tables (`academies`, `profiles`). The policies now include a check `OR public.is_platform_admin()`, granting platform admins the necessary permissions to manage the system.

This also includes the previous frontend simplification to the login component, making the code cleaner and more aligned with the backend logic.