### PR TITLE
Fix(data): Use public_pages for academy website content

### DIFF
--- a/src/components/public/AcademyWebsite.tsx
+++ b/src/components/public/AcademyWebsite.tsx
@@ -43,9 +43,10 @@ const AcademyWebsite = ({ section }: { section?: string }) => {
 
         // Fetch website content
         const { data: contentData, error: contentError } = await supabase
-          .from('website_content')
+          .from('public_pages')
           .select('content')
           .eq('academy_id', academyData.id)
+          .eq('slug', 'homepage')
           .single();
 
         if (contentError && contentError.code !== 'PGRST116') { // PGRST116 means no rows found


### PR DESCRIPTION
The AcademyWebsite component was querying a non-existent table 'website_content' to fetch the public-facing content for an academy. This caused an error and prevented the academy websites from loading.

This commit corrects the query to use the 'public_pages' table and filter for the page with the slug 'homepage', which is the intended source for this content as defined during academy creation.